### PR TITLE
Update builder-install image version used in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 version: 2.1
 
 defaults:
-  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_23
+  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_25
   default-environment: &default-environment
     RUST_BACKTRACE: 1
     SKIP_SLOW_TESTS: 1


### PR DESCRIPTION
1.25 was published with https://github.com/mobilecoinfoundation/mobilecoin/pull/1307