### PR TITLE
Adding stash_size function for diagnostics

### DIFF
--- a/mc-oblivious-ram/src/path_oram/mod.rs
+++ b/mc-oblivious-ram/src/path_oram/mod.rs
@@ -166,6 +166,19 @@ where
     fn len(&self) -> u64 {
         self.pos.len()
     }
+
+    fn stash_size(&self) -> usize {
+        let mut stash_count = 0u64;
+        for idx in 0..self.stash_data.len() {
+            let stash_count_incremented = stash_count + 1;
+            stash_count.cmov(
+                meta_is_vacant(&self.stash_meta[idx]),
+                &stash_count_incremented,
+            );
+        }
+        stash_count as usize
+    }
+
     // TODO: We should try implementing a circuit-ORAM like approach also
     fn access<T, F: FnOnce(&mut A64Bytes<ValueSize>) -> T>(&mut self, key: u64, f: F) -> T {
         let result: T;

--- a/mc-oblivious-traits/src/lib.rs
+++ b/mc-oblivious-traits/src/lib.rs
@@ -121,6 +121,10 @@ pub trait ORAM<ValueSize: ArrayLength<u8>> {
     /// accessed.
     fn len(&self) -> u64;
 
+    /// Get the number of values in the ORAM's stash for diagnostics. In prod,
+    /// this number should be viewed as secret and not revealed.
+    fn stash_size(&self) -> usize;
+
     /// Access the ORAM at a position, calling a lambda with the recovered
     /// value, and returning the result of the lambda.
     /// This cannot fail, but will panic if index is out of bounds.

--- a/mc-oblivious-traits/src/linear_scanning.rs
+++ b/mc-oblivious-traits/src/linear_scanning.rs
@@ -21,6 +21,11 @@ impl<ValueSize: ArrayLength<u8>> ORAM<ValueSize> for LinearScanningORAM<ValueSiz
     fn len(&self) -> u64 {
         self.data.len() as u64
     }
+
+    fn stash_size(&self) -> usize {
+        0
+    }
+
     fn access<T, F: FnOnce(&mut A64Bytes<ValueSize>) -> T>(&mut self, query: u64, f: F) -> T {
         let mut temp: A64Bytes<ValueSize> = Default::default();
         for idx in 0..self.data.len() {


### PR DESCRIPTION
This stash_size feature is useful for debugging stash size growth in orams that use stashes. In particular it is useful to determine if new oram implementations like CircuitOram have linear stash growth. Subsequent Prs will use this in testing and analysis.