### PR TITLE
Circuit oram/adding linearity test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,26 @@
 version = 3
 
 [[package]]
+name = "GSL"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9becaf6d7d1ba36a457288e661fa6a0472e8328629276f45369eafcd48ef1ce"
+dependencies = [
+ "GSL-sys",
+ "paste",
+]
+
+[[package]]
+name = "GSL-sys"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577670dcc0720995dc39f04c438595eaae8ccc27f4aafd3e572dd408d01bd9d"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "aligned-array"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +344,7 @@ dependencies = [
 name = "mc-oblivious-ram"
 version = "2.2.0"
 dependencies = [
+ "GSL",
  "aligned-cmov",
  "balanced-tree-index",
  "mc-oblivious-traits",
@@ -379,6 +400,18 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "paste"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "plotters"

--- a/mc-oblivious-ram/Cargo.toml
+++ b/mc-oblivious-ram/Cargo.toml
@@ -22,3 +22,4 @@ rand_core = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 test-helper = { path = "../test-helper" }
+GSL = "6.0.0"

--- a/mc-oblivious-ram/src/lib.rs
+++ b/mc-oblivious-ram/src/lib.rs
@@ -23,6 +23,7 @@
 #![deny(unsafe_code)]
 
 extern crate alloc;
+extern crate std;
 
 use aligned_cmov::typenum::{U1024, U2, U2048, U32, U4, U4096, U64};
 use core::marker::PhantomData;
@@ -94,10 +95,14 @@ where
 
 #[cfg(test)]
 mod testing {
+    extern crate rgsl;
     use super::*;
 
     use aligned_cmov::{A64Bytes, ArrayLength};
+    use alloc::collections::BTreeMap;
+    use core::convert::TryInto;
     use mc_oblivious_traits::{rng_maker, testing, HeapORAMStorageCreator, ORAM};
+    use std::vec;
     use test_helper::{run_with_several_seeds, RngType};
 
     const STASH_SIZE: usize = 16;
@@ -342,6 +347,103 @@ mod testing {
                 8192, STASH_SIZE, &mut maker,
             );
             testing::exercise_oram_consecutive(20_000, &mut oram, &mut rng);
+        });
+    }
+
+
+    // Run the analysis oram tests similar to CircuitOram section 5. Warm up with
+    // 2^10 accesses, then run for 2^20 accesses cycling through all N logical
+    // addresses. N=2^10. This choice is arbitrary because stash size should not
+    // depend on N. Measure the number of times that the stash is above any
+    // given size.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn analysis_path_oram_z4_8192() {
+        const STASH_SIZE: usize = 32;
+        run_with_several_seeds(|rng| {
+            let base: u64 = 2;
+            let num_rounds: u64 = base.pow(30);
+            let mut maker = rng_maker(rng);
+            let mut rng = maker();
+            let mut oram = PathORAM4096Z4Creator::<RngType, HeapORAMStorageCreator>::create(
+                base.pow(10),
+                STASH_SIZE,
+                &mut maker,
+            );
+            let stash_stats = testing::measure_oram_stash_size_distribution(
+                base.pow(10).try_into().unwrap(),
+                num_rounds.try_into().unwrap(),
+                &mut oram,
+                &mut rng,
+            );
+            let mut x_axis: vec::Vec<f64> = vec::Vec::new();
+            let mut y_axis: vec::Vec<f64> = vec::Vec::new();
+            std::eprintln!("key: {}, has_value: {}", 0, stash_stats.get(&0).unwrap());
+            for stash_count in 1..STASH_SIZE {
+                if let Some(stash_count_probability) = stash_stats.get(&stash_count) {
+                    std::eprintln!(
+                        "key: {}, has_value: {}",
+                        stash_count,
+                        stash_count_probability
+                    );
+                    y_axis.push((num_rounds as f64 / *stash_count_probability as f64).log2());
+                    x_axis.push(stash_count as f64);
+                } else {
+                    std::eprintln!("Key: {}, has no value", stash_count);
+                }
+            }
+
+            let correlation = rgsl::statistics::correlation(&x_axis, 1, &y_axis, 1, x_axis.len());
+            std::eprintln!("Correlation: {}", correlation);
+            assert!(correlation > 0.9);
+        });
+    }
+
+    // Test for stash performance independence for changing N (Oram size) without changing number of calls.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn test_oram_n_independence() {
+        const STASH_SIZE: usize = 32;
+        const BASE: u64 = 2;
+        const NUM_ROUNDS: u64 = BASE.pow(20);
+
+        run_with_several_seeds(|rng| {
+            let mut statistics_agregate = BTreeMap::<u32, BTreeMap<usize, usize>>::default();
+            let mut maker = rng_maker(rng);
+            for oram_power in (10..24).step_by(2) {
+                let mut rng = maker();
+                let mut oram = PathORAM4096Z4Creator::<RngType, HeapORAMStorageCreator>::create(
+                    BASE.pow(oram_power),
+                    STASH_SIZE,
+                    &mut maker,
+                );
+                let stash_stats = testing::measure_oram_stash_size_distribution(
+                    BASE.pow(10).try_into().unwrap(),
+                    NUM_ROUNDS.try_into().unwrap(),
+                    &mut oram,
+                    &mut rng,
+                );
+                statistics_agregate.insert(oram_power, stash_stats);
+            }
+            for stash_num in 1..6 {
+                let mut probability_of_stash_size = vec::Vec::new();
+                for stash_stats in &statistics_agregate {
+                    if let Some(stash_count) = stash_stats.1.get(&stash_num) {
+                        std::eprintln!("key: {}, has_value: {}, for oram_power: {}", stash_num, stash_count, stash_stats.0);
+                        let stash_count_probability =
+                            (NUM_ROUNDS as f64 / *stash_count as f64).log2();
+                        probability_of_stash_size.push(stash_count_probability);
+                    } else {
+                        std::eprintln!("Key: {}, has no value for oram_power: {}", stash_num, stash_stats.0);
+                    }
+                }
+                let data_variance = rgsl::statistics::variance(
+                    &probability_of_stash_size,
+                    1,
+                    probability_of_stash_size.len(),
+                );
+                assert!(data_variance < 0.05);
+            }
         });
     }
 

--- a/mc-oblivious-ram/src/path_oram/mod.rs
+++ b/mc-oblivious-ram/src/path_oram/mod.rs
@@ -166,6 +166,19 @@ where
     fn len(&self) -> u64 {
         self.pos.len()
     }
+
+    fn stash_size(&self) -> usize {
+        let mut stash_count = 0u64;
+        for idx in 0..self.stash_data.len() {
+            let stash_count_incremented = stash_count + 1;
+            stash_count.cmov(
+                meta_is_vacant(&self.stash_meta[idx]),
+                &stash_count_incremented,
+            );
+        }
+        stash_count as usize
+    }
+
     // TODO: We should try implementing a circuit-ORAM like approach also
     fn access<T, F: FnOnce(&mut A64Bytes<ValueSize>) -> T>(&mut self, key: u64, f: F) -> T {
         let result: T;

--- a/mc-oblivious-traits/src/lib.rs
+++ b/mc-oblivious-traits/src/lib.rs
@@ -121,6 +121,10 @@ pub trait ORAM<ValueSize: ArrayLength<u8>> {
     /// accessed.
     fn len(&self) -> u64;
 
+    /// Get the number of values in the ORAM's stash for diagnostics. In prod,
+    /// this number should be viewed as secret and not revealed.
+    fn stash_size(&self) -> usize;
+
     /// Access the ORAM at a position, calling a lambda with the recovered
     /// value, and returning the result of the lambda.
     /// This cannot fail, but will panic if index is out of bounds.

--- a/mc-oblivious-traits/src/linear_scanning.rs
+++ b/mc-oblivious-traits/src/linear_scanning.rs
@@ -21,6 +21,11 @@ impl<ValueSize: ArrayLength<u8>> ORAM<ValueSize> for LinearScanningORAM<ValueSiz
     fn len(&self) -> u64 {
         self.data.len() as u64
     }
+
+    fn stash_size(&self) -> usize {
+        0
+    }
+
     fn access<T, F: FnOnce(&mut A64Bytes<ValueSize>) -> T>(&mut self, query: u64, f: F) -> T {
         let mut temp: A64Bytes<ValueSize> = Default::default();
         for idx in 0..self.data.len() {

--- a/mc-oblivious-traits/src/testing.rs
+++ b/mc-oblivious-traits/src/testing.rs
@@ -71,6 +71,56 @@ where
     }
 }
 
+/// Exercise an ORAM by writing, reading, and rewriting, first cycling through
+/// all N locations num_pre_rounds times to warm up the oram, then repeatedly
+/// cycling through all N locations a total of num_rounds times as a worst case
+/// access sequence and measuring the stash size.
+pub fn measure_oram_stash_size_distribution<BlockSize, O, R>(
+    mut num_pre_rounds: usize,
+    mut num_rounds: usize,
+    oram: &mut O,
+    rng: &mut R,
+) -> BTreeMap<usize, usize>
+where
+    BlockSize: ArrayLength<u8>,
+    O: ORAM<BlockSize>,
+    R: RngCore + CryptoRng,
+{
+    let len = oram.len();
+    assert!(len != 0, "len is zero");
+    assert_eq!(len & (len - 1), 0, "len is not a power of two");
+
+    let mut expected = BTreeMap::<u64, A64Bytes<BlockSize>>::default();
+    let mut probe_idx = 0u64;
+    let mut statistics = BTreeMap::<usize, usize>::default();
+
+    while num_pre_rounds > 0 {
+        let expected_ent = expected.entry(probe_idx).or_default();
+
+        oram.access(probe_idx, |val| {
+            assert_eq!(val, expected_ent);
+            rng.fill_bytes(val);
+            expected_ent.clone_from_slice(val.as_slice());
+        });
+        probe_idx = (probe_idx + 1) & (len - 1);
+        num_pre_rounds -= 1;
+    }
+
+    while num_rounds > 0 {
+        let expected_ent = expected.entry(probe_idx).or_default();
+
+        oram.access(probe_idx, |val| {
+            assert_eq!(val, expected_ent);
+            rng.fill_bytes(val);
+            expected_ent.clone_from_slice(val.as_slice());
+        });
+        *statistics.entry(oram.stash_size()).or_default() += 1;
+        probe_idx = (probe_idx + 1) & (len - 1);
+        num_rounds -= 1;
+    }
+    statistics
+}
+
 /// Exercise an OMAP by writing, reading, accessing, and removing a
 /// progressively larger set of random locations
 pub fn exercise_omap<KeySize, ValSize, O, R>(mut num_rounds: usize, omap: &mut O, rng: &mut R)


### PR DESCRIPTION
Adding measure_oram_stash_size_distribution function that returns stash size statistics
Adding tests for stash size independence with respect to oram size
Adding tests for stash size linear growth with respect to time.

These tests are generally useful for determining whether our Oram implementations are well behaved, and helps validate changes to our oram.