### PR TITLE
using rustup install stable instead of directly calling cargo install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,8 +111,8 @@ commands:
       - run:
           name: Install CI dependencies
           command: |
-            command -v cargo-cache >/dev/null || cargo install cargo-cache
-            command -v cargo2junit >/dev/null || cargo install cargo2junit
+            command -v cargo-cache >/dev/null || rustup run --install stable cargo install cargo-cache
+            command -v cargo2junit >/dev/null || rustup run --install stable cargo install cargo2junit
   prefetch-cargo-deps:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ commands:
           name: Install Rust
           command: |
             command -v rustup >/dev/null || \
-              curl https://sh.rustup.rs --tlsv1.2 -sSf | sh -s -- -y --default-toolchain none
+              curl https://sh.rustup.rs --tlsv1.2 -sSf | sh -s -- -y --default-toolchain stable
             # Installs the toolchain specified in `rust-toolchain`
             "$HOME/.cargo/bin/rustup" show active-toolchain
   install-ci-deps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,6 @@ commands:
             cargo bench
 
 jobs:
-
   # Run all tests on a single container
   run-all-tests:
     executor: build-executor


### PR DESCRIPTION
Ci seems to be running into an [issue with crossbeam epoch](https://app.circleci.com/pipelines/github/mobilecoinfoundation/mc-oblivious/60/workflows/27a66478-a13f-41de-a628-df76d87ee452/jobs/294) when calling cargo install cargo2junit. This change brings us inline with the main mobilecoin repo and Remoun has suggested that this will also fix the issue. 