### PR TITLE
Updating lint script to match mobilecoin repo

### DIFF
--- a/balanced-tree-index/src/lib.rs
+++ b/balanced-tree-index/src/lib.rs
@@ -429,7 +429,7 @@ mod testing {
         let mut it1 = lhs.parents();
         let mut it2 = rhs.parents();
         while it1.next().unwrap() != it2.next().unwrap() {
-            counter = counter + 1;
+            counter += 1;
         }
         counter
     }

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,16 +1,23 @@
 #!/bin/bash
 
-# Copyright (c) 2018-2020 MobileCoin Inc.
+# Copyright (c) 2018-2022 The MobileCoin Foundation
 
-set -e
+set -e  # exit on error
 
 if [[ ! -z "$1" ]]; then
     cd "$1"
 fi
 
+# We want to check with --all-targets since it checks test code, but that flag
+# leads to build errors in enclave workspaces, so check it here.
+cargo clippy --all --all-features --all-targets
+
+cargo install cargo-sort
+
 for toml in $(grep --exclude-dir cargo --exclude-dir rust-mbedtls --include=Cargo.toml -r . -e '\[workspace\]' | cut -d: -f1); do
   pushd $(dirname $toml) >/dev/null
   echo "Linting in $PWD"
+  cargo sort --workspace --grouped --check
   cargo fmt -- --unstable-features --check
   cargo clippy --all --all-features
   echo "Linting in $PWD complete."


### PR DESCRIPTION
The lint script in the mobilecoin repo was updated, and it seemed appropriate to port the change here and keep them in sync.