### PR TITLE
Fix/bench cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,8 @@ dependencies = [
 name = "test-helper"
 version = "2.0.0"
 dependencies = [
+ "aligned-array",
+ "aligned-cmov",
  "rand_core",
  "rand_hc",
 ]

--- a/mc-oblivious-map/Cargo.toml
+++ b/mc-oblivious-map/Cargo.toml
@@ -26,7 +26,7 @@ siphasher = "0.3"
 mc-oblivious-ram = { path = "../mc-oblivious-ram" }
 test-helper = { path = "../test-helper" }
 
-criterion = "0.3"
+criterion = {version = "0.3", features = ["html_reports"]}
 
 # This is only needed by benchmarks... we should really put this on crates.io
 mc-crypto-rand = { git = "https://github.com/mobilecoinfoundation/mobilecoin", rev = "9653694d5fcd8fb9438728547467518b634d6cf5" }

--- a/mc-oblivious-map/benches/ingest.rs
+++ b/mc-oblivious-map/benches/ingest.rs
@@ -1,12 +1,13 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use aligned_cmov::{typenum, A8Bytes, ArrayLength};
+use aligned_cmov::{typenum, A8Bytes};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use mc_crypto_rand::McRng;
 use mc_oblivious_map::{CuckooHashTable, CuckooHashTableCreator};
 use mc_oblivious_ram::PathORAM4096Z4Creator;
 use mc_oblivious_traits::{HeapORAMStorageCreator, OMapCreator, ORAMCreator, ObliviousHashMap};
 use std::time::Duration;
+use test_helper::a8_8;
 use typenum::{U1024, U32};
 
 type ORAMCreatorZ4 = PathORAM4096Z4Creator<McRng, HeapORAMStorageCreator>;
@@ -16,16 +17,6 @@ type CuckooCreatorZ4 = CuckooHashTableCreator<U1024, McRng, ORAMCreatorZ4>;
 
 fn make_omap(capacity: u64) -> Table {
     CuckooCreatorZ4::create(capacity, 32, || McRng {})
-}
-
-/// Make a8-bytes that are initialized to a particular byte value
-/// This makes tests shorter to write
-fn a8_8<N: ArrayLength<u8>>(src: u8) -> A8Bytes<N> {
-    let mut result = A8Bytes::<N>::default();
-    for byte in result.as_mut_slice() {
-        *byte = src;
-    }
-    result
 }
 
 pub fn path_oram_4096_z4_1mil_ingest_write(c: &mut Criterion) {

--- a/mc-oblivious-map/benches/view.rs
+++ b/mc-oblivious-map/benches/view.rs
@@ -1,12 +1,13 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use aligned_cmov::{typenum, A8Bytes, ArrayLength};
+use aligned_cmov::{typenum, A8Bytes};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use mc_crypto_rand::McRng;
 use mc_oblivious_map::{CuckooHashTable, CuckooHashTableCreator};
 use mc_oblivious_ram::PathORAM4096Z4Creator;
 use mc_oblivious_traits::{HeapORAMStorageCreator, OMapCreator, ORAMCreator, ObliviousHashMap};
 use std::time::Duration;
+use test_helper::a8_8;
 use typenum::{U1024, U16, U240};
 
 type ORAMCreatorZ4 = PathORAM4096Z4Creator<McRng, HeapORAMStorageCreator>;
@@ -16,16 +17,6 @@ type CuckooCreatorZ4 = CuckooHashTableCreator<U1024, McRng, ORAMCreatorZ4>;
 
 fn make_omap(capacity: u64) -> Table {
     CuckooCreatorZ4::create(capacity, 32, || McRng {})
-}
-
-/// Make a8-bytes that are initialized to a particular byte value
-/// This makes tests shorter to write
-fn a8_8<N: ArrayLength<u8>>(src: u8) -> A8Bytes<N> {
-    let mut result = A8Bytes::<N>::default();
-    for byte in result.as_mut_slice() {
-        *byte = src;
-    }
-    result
 }
 
 pub fn path_oram_4096_z4_1mil_view_write(c: &mut Criterion) {

--- a/no-asm-tests/Cargo.lock
+++ b/no-asm-tests/Cargo.lock
@@ -93,6 +93,8 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 name = "test-helper"
 version = "2.0.0"
 dependencies = [
+ "aligned-array",
+ "aligned-cmov",
  "rand_core",
  "rand_hc",
 ]

--- a/test-helper/Cargo.toml
+++ b/test-helper/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2018"
 [dependencies]
 rand_core = { version = "0.6", default-features = false }
 rand_hc = "0.3"
+aligned-array = { version = "1", features = ["subtle"] }
+aligned-cmov = { path = "../aligned-cmov", version = "2.2" }

--- a/test-helper/Cargo.toml
+++ b/test-helper/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Chris Beck <beck.ct@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-rand_core = { version = "0.6", default-features = false }
-rand_hc = "0.3"
 aligned-array = { version = "1", features = ["subtle"] }
 aligned-cmov = { path = "../aligned-cmov", version = "2.2" }
+rand_core = { version = "0.6", default-features = false }
+rand_hc = "0.3"

--- a/test-helper/src/lib.rs
+++ b/test-helper/src/lib.rs
@@ -1,3 +1,4 @@
+use aligned_cmov::{A8Bytes, ArrayLength};
 pub use rand_core::{CryptoRng, RngCore, SeedableRng};
 use rand_hc::Hc128Rng;
 type Seed = <RngType as SeedableRng>::Seed;
@@ -32,4 +33,14 @@ fn get_seeds() -> [Seed; NUM_TRIALS] {
 
 pub fn get_seeded_rng() -> RngType {
     RngType::from_seed([7u8; 32])
+}
+
+/// Make a8-bytes that are initialized to a particular byte value
+/// This makes tests shorter to write
+pub fn a8_8<N: ArrayLength<u8>>(src: u8) -> A8Bytes<N> {
+    let mut result = A8Bytes::<N>::default();
+    for byte in result.as_mut_slice() {
+        *byte = src;
+    }
+    result
 }


### PR DESCRIPTION
Adding html_reports to cargo toml for bench tests because it is no longer a default feature.
Refactoring out a8_8 testing function into the test_helper for reusability.