### PR TITLE
Add an access_and_remove API to oblivious map

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -78,7 +78,7 @@ else
 	exit 1
 fi
 
-CARGOFMT="cargo fmt"
+CARGOFMT="cargo fmt --"
 
 # Just check that running rustfmt doesn't do anything to the file. I do this instead of
 # modifying the file because I don't want to mess with the developer's index, which may

--- a/mc-oblivious-map/src/lib.rs
+++ b/mc-oblivious-map/src/lib.rs
@@ -283,7 +283,7 @@ where
         // All zeroes is an invalid key, because we use that as a sentinel to detect
         // free spots in the hashmap. In this scenario, we give the callback
         // OMAP_INVALID_KEY and pass an empty buffer which is later discarded.
-        let query_is_valid = query.ct_ne(&A8Bytes::<KeySize>::default());
+        let query_is_valid = !query.ct_eq(&A8Bytes::<KeySize>::default());
 
         let hashes = self.hash_query(query);
         let oram1 = &mut self.oram1;
@@ -294,7 +294,7 @@ where
                 // If we never find the item, we will pass OMAP_NOT_FOUND to callback,
                 // and we will not insert it, no matter what the callback does.
                 let mut result_code = OMAP_INVALID_KEY;
-                result_code.cmov(query_is_valid, OMAP_NOT_FOUND);
+                result_code.cmov(query_is_valid, &OMAP_NOT_FOUND);
                 for block in &[&block1, &block2] {
                     let pairs: &[A8Bytes<Sum<KeySize, ValueSize>>] = block.as_aligned_chunks();
                     for pair in pairs {

--- a/mc-oblivious-map/src/lib.rs
+++ b/mc-oblivious-map/src/lib.rs
@@ -856,13 +856,21 @@ mod testing {
 
             omap.access_and_remove(&a8_8(2), |code, buffer| {
                 assert_eq!(code, OMAP_FOUND);
-                assert_eq!(buffer, &a8_8(20), "omap.write must not modify when overwrite is disallowed");
+                assert_eq!(
+                    buffer,
+                    &a8_8(20),
+                    "omap.write must not modify when overwrite is disallowed"
+                );
                 Choice::from(0)
             });
 
             omap.access_and_remove(&a8_8(2), |code, buffer| {
                 assert_eq!(code, OMAP_FOUND);
-                assert_eq!(buffer, &a8_8(20), "omap.access_and_remove should not delete when delete is false");
+                assert_eq!(
+                    buffer,
+                    &a8_8(20),
+                    "omap.access_and_remove should not delete when delete is false"
+                );
                 Choice::from(0)
             });
 
@@ -873,13 +881,24 @@ mod testing {
 
             omap.access_and_remove(&a8_8(2), |code, buffer| {
                 assert_eq!(code, OMAP_FOUND);
-                assert_eq!(buffer, &a8_8(30), "omap.write must modify when overwrite is allowed");
+                assert_eq!(
+                    buffer,
+                    &a8_8(30),
+                    "omap.write must modify when overwrite is allowed"
+                );
                 Choice::from(1)
             });
 
             omap.access(&a8_8(2), |code, buffer| {
-                assert_eq!(code, OMAP_NOT_FOUND, "omap.access_and_remove should delete when delete is true");
-                assert_eq!(buffer, &a8_8(0), "when data is not present, access should give us all zeroes buffer");
+                assert_eq!(
+                    code, OMAP_NOT_FOUND,
+                    "omap.access_and_remove should delete when delete is true"
+                );
+                assert_eq!(
+                    buffer,
+                    &a8_8(0),
+                    "when data is not present, access should give us all zeroes buffer"
+                );
             });
         })
     }

--- a/mc-oblivious-traits/src/lib.rs
+++ b/mc-oblivious-traits/src/lib.rs
@@ -310,7 +310,7 @@ pub trait ObliviousHashMap<KeySize: ArrayLength<u8>, ValueSize: ArrayLength<u8>>
         // By default we call to access-and-remove and always elect not to remove.
         // The perf consequence of this is usually very small, so this is a reasonable
         // default implementation.
-        self.access_and_remove(key, |(code, val)| -> Choice {
+        self.access_and_remove(key, |code, val| -> Choice {
             callback(code, val);
             Choice::from(0)
         })


### PR DESCRIPTION
Also:
* make default impementation of `access` call to `access_and_remove`
* make `access_and_remove` not early return if the query is all zeroes, instead, be constant-time even in that case.
* Add some unit tests of the remove functionality.

---

This is meant to support some functionality in mc-bomb