### PR TITLE
fix number of crate categories for aligned-cmov

### DIFF
--- a/aligned-cmov/Cargo.toml
+++ b/aligned-cmov/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 edition = "2018"
 readme = "README.md"
 repository = "https://github.com/mobilecoinofficial/mc-oblivious"
-keywords = ["aligned", "alignment", "cryptography", "crypto", "constant-time", "utilities"]
+keywords = ["aligned", "alignment", "cryptography", "constant-time", "utilities"]
 categories = ["embedded", "memory-management", "cryptography", "no-std"]
 
 [features]


### PR DESCRIPTION
cargo publish rejected this, it said 6 is too many